### PR TITLE
Clean up backfilling code and enhance validation

### DIFF
--- a/backfilling/extract_auction_location_data.py
+++ b/backfilling/extract_auction_location_data.py
@@ -93,7 +93,11 @@ def extract_auction_fields(data: Dict) -> Optional[Dict[str, any]]:
         postal_code = approx_location.get('postalCode')
         
         # Check if required fields exist
-        if am_auction_id is None or lat is None or lng is None:
+        if am_auction_id is None or lat is None or lng is None or postal_code is None:
+            return None
+        
+        # Enforce Canadian postal code (6 characters, excluding spaces)
+        if len(postal_code.replace(' ', '')) != 6:
             return None
         
         return {


### PR DESCRIPTION
Improve validation by ensuring the presence of the postal code and enforcing its format for Canadian addresses.